### PR TITLE
<#4> Global style 설정

### DIFF
--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { globalStyle } from './styles/global';
+
 import App from './App';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { ThemeProvider } from 'styled-components';
 
-import { globalStyle } from './styles/global';
+import { GlobalStyle } from './styles/global';
+
+import { lightTheme, darkTheme } from './styles/theme';
 
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+  <ThemeProvider theme={darkTheme}>
+    <GlobalStyle />
+    <App />
+  </ThemeProvider>,
+  document.getElementById('root'),
+);

--- a/front/src/styles/global.ts
+++ b/front/src/styles/global.ts
@@ -1,0 +1,64 @@
+import { createGlobalStyle } from 'styled-components';
+
+export const globalStyle = createGlobalStyle`
+  @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400&display=swap');
+  html, body, div, span, applet, object, iframe,
+  h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+  a, abbr, acronym, address, big, cite, code,
+  del, dfn, em, img, ins, kbd, q, s, samp,
+  small, strike, strong, sub, sup, tt, var,
+  b, u, i, center,
+  dl, dt, dd, menu, ol, ul, li,
+  fieldset, form, label, legend,
+  table, caption, tbody, tfoot, thead, tr, th, td,
+  article, aside, canvas, details, embed,
+  figure, figcaption, footer, header, hgroup,
+  main, menu, nav, output, ruby, section, summary,
+  time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article, aside, details, figcaption, figure,
+  footer, header, hgroup, main, menu, nav, section {
+    display: block;
+  }
+  /* HTML5 hidden-attribute fix for newer browsers */
+  *[hidden] {
+    display: none;
+  }
+  body {
+    line-height: 1;
+  }
+  menu, ol, ul {
+    list-style: none;
+  }
+  blockquote, q {
+    quotes: none;
+  }
+  blockquote:before, blockquote:after,
+  q:before, q:after {
+  content: '';
+  content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+  * {
+    box-sizing: border-box;
+  }
+  body {
+    font-family: 'Source Sans Pro', sans-serif;
+    background-color: 'whitesmoke';
+    color : 'black';
+
+  }
+  a {
+    text-decoration:none;
+  }
+`;

--- a/front/src/styles/global.ts
+++ b/front/src/styles/global.ts
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
-export const globalStyle = createGlobalStyle`
+export const GlobalStyle = createGlobalStyle`
   @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400&display=swap');
   html, body, div, span, applet, object, iframe,
   h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -54,10 +54,10 @@ export const globalStyle = createGlobalStyle`
   }
   body {
     font-family: 'Source Sans Pro', sans-serif;
-    background-color: 'whitesmoke';
-    color : 'black';
-
+    background-color: ${(props) => props.theme.color.bgColor};
+    color : ${(props) => props.theme.color.textColor};
   }
+
   a {
     text-decoration:none;
   }

--- a/front/src/styles/styled.d.ts
+++ b/front/src/styles/styled.d.ts
@@ -1,0 +1,53 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    margins: {
+      sm: string;
+      base: string;
+      lg: string;
+      xl: string;
+    };
+
+    paddings: {
+      sm: string;
+      base: string;
+      lg: string;
+      xl: string;
+    };
+
+    fonts: {
+      family: {
+        base: string;
+        title: string;
+      };
+
+      size: {
+        sm: string;
+        base: string;
+        lg: string;
+        xl: string;
+        title: string;
+      };
+
+      weight: {
+        light: string;
+        normal: string;
+        bold: string;
+      };
+
+      colors: {
+        white: string;
+        darkWhite: string;
+        red: string;
+        yellow: string;
+        blue: string;
+        dark: string;
+        light: string;
+        primary: string;
+        bgColor: string;
+        textColor: string;
+      };
+    };
+  }
+}

--- a/front/src/styles/styled.d.ts
+++ b/front/src/styles/styled.d.ts
@@ -31,23 +31,23 @@ declare module 'styled-components' {
       };
 
       weight: {
-        light: string;
-        normal: string;
-        bold: string;
+        light: number;
+        normal: number;
+        bold: number;
       };
+    };
 
-      colors: {
-        white: string;
-        darkWhite: string;
-        red: string;
-        yellow: string;
-        blue: string;
-        dark: string;
-        light: string;
-        primary: string;
-        bgColor: string;
-        textColor: string;
-      };
+    color: {
+      white: string;
+      darkWhite: string;
+      red: string;
+      yellow: string;
+      blue: string;
+      dark: string;
+      light: string;
+      primary: string;
+      bgColor: string;
+      textColor: string;
     };
   }
 }

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -1,0 +1,76 @@
+const margins = {
+  sm: '.5rem',
+  base: '1rem',
+  lg: '2rem',
+  xl: '3rem',
+};
+
+const paddings = {
+  sm: '.5rem',
+  base: '1rem',
+  lg: '2rem',
+  xl: '3rem',
+};
+
+const fonts = {
+  family: {
+    base: `'Noto Sans KR', sans-serif`,
+    title: `'Merriweather', serif`,
+  },
+  size: {
+    sm: '1.2rem',
+    base: '1.5rem',
+    lg: '2rem',
+    xl: '2.5rem',
+    title: '6rem',
+  },
+  weight: {
+    light: 100,
+    normal: 400,
+    bold: 700,
+  },
+};
+
+const colors = {
+  white: '#fff',
+  darkWhite: '#f0f0f0',
+  red: '#ff4d4d',
+  yellow: '#ffff4d',
+  blue: '#0099ff',
+
+  dark: '#333',
+  light: 'fff',
+};
+
+// 테마에 따라 다른 값을 갖는 색상 값입니다
+const lightThemeColors = {
+  ...colors,
+  primary: '#22b8cf',
+  bgColor: colors.white,
+  textColor: colors.dark,
+};
+
+const darkThemeColors = {
+  ...colors,
+  primary: '#22b8cf',
+  bgColor: colors.dark,
+  textColor: colors.white,
+};
+
+// 테마와 관련없이 공통으로 사용되는 변수들입니다
+const defalutTheme = {
+  margins,
+  paddings,
+  fonts,
+};
+
+// 각 테마는 공통 변수와 함께, 각기 다른 색상 값들을 갖습니다.
+export const darkTheme = {
+  ...defalutTheme,
+  colors: darkThemeColors,
+};
+
+export const lightTheme = {
+  ...defalutTheme,
+  colors: lightThemeColors,
+};

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -1,3 +1,5 @@
+import { DefaultTheme } from 'styled-components';
+
 const margins = {
   sm: '.5rem',
   base: '1rem',
@@ -39,7 +41,7 @@ const colors = {
   blue: '#0099ff',
 
   dark: '#333',
-  light: 'fff',
+  light: '#fff',
 };
 
 // 테마에 따라 다른 값을 갖는 색상 값입니다
@@ -65,12 +67,12 @@ const defalutTheme = {
 };
 
 // 각 테마는 공통 변수와 함께, 각기 다른 색상 값들을 갖습니다.
-export const darkTheme = {
+export const darkTheme: DefaultTheme = {
   ...defalutTheme,
-  colors: darkThemeColors,
+  color: darkThemeColors,
 };
 
-export const lightTheme = {
+export const lightTheme: DefaultTheme = {
   ...defalutTheme,
-  colors: lightThemeColors,
+  color: lightThemeColors,
 };


### PR DESCRIPTION
## 내용
- reset CSS를 이용한 global Style 설정 (css 초기화)
> 관련 링크:  https://meyerweb.com/eric/tools/css/reset/

- theme 설정 : color, margin, padding, font 크기를 설정

## 느낀점
- typescript가 익숙치 않아서 타입 설정에 대한 부담이 있었지만 아직까지는 괜찮은 것 같다.

```ts
  body {
    font-family: 'Source Sans Pro', sans-serif;
    background-color: ${(props) => props.theme.color.bgColor};
    color : ${(props) => props.theme.color.textColor};
 }
``` 
- 사실 타입스크립트가 정해지지 않은 인자에 대해서는 확실하게 타입을 지정해주어야 된다고 생각했는데 위의 코드의 경우 따로 타입을 지정해 주지 않아도 에러를 불러 일으키지 않는다. (이유를 찾아보아야 겠다.)

### 관련 이슈 #4 