### PR TITLE
<#18> CoinDetail Page 스타일링

### DIFF
--- a/front/src/components/CoinInfo.tsx
+++ b/front/src/components/CoinInfo.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { CoinInfoProps } from '../types/types';
+
+import { Container, Center } from '../layout/layout';
+
+const CoinInfo = ({ info, price }: CoinInfoProps) => {
+  return (
+    <InfoContainer>
+      <InfoRank>
+        <p>Rank</p>
+        <p>{info?.rank}</p>
+      </InfoRank>
+      <InfoSymbol>
+        <p>Symbol</p>
+        <p>{info?.symbol}</p>
+      </InfoSymbol>
+      <InfoSource>
+        <div>
+          <p>Open</p>
+          <p>Source</p>
+        </div>
+        <p>{JSON.stringify(info?.open_source)}</p>
+      </InfoSource>
+      <InfoDescription>{info?.description}</InfoDescription>
+
+      <PriceTotal>
+        <p>TOTAL SUPPLY</p>
+        <p>{price?.total_supply}</p>
+      </PriceTotal>
+      <PriceMax>
+        <p>MAX SUPPY</p>
+        <p>{price?.max_supply}</p>
+      </PriceMax>
+    </InfoContainer>
+  );
+};
+
+const InfoLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+const InfoStyle = styled(InfoLayout)`
+  height: 100%;
+  width: 100%;
+
+  ${({ theme }) => {
+    return css`
+      background-color: ${theme.color.secondary};
+    `;
+  }}
+`;
+
+const InfoContainer = styled(Container)`
+  width: 50vw;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 100px;
+
+  gap: 8px;
+
+  ${({ theme }) => {
+    return css`
+      color: ${theme.color.white};
+    `;
+  }}
+`;
+
+const InfoRank = styled(InfoStyle)``;
+
+const InfoSymbol = styled(InfoStyle)`
+  grid-column: 2 / -2;
+`;
+
+const InfoSource = styled(InfoStyle)``;
+
+const InfoDescription = styled(Center)`
+  overflow-y: auto;
+  grid-column: 1 / -1;
+
+  ${({ theme }) => {
+    return css`
+      color: ${theme.color.primary};
+      padding-left: ${theme.paddings.base};
+      padding-right: ${theme.paddings.base};
+    `;
+  }}
+`;
+
+const PriceTotal = styled(InfoStyle)`
+  grid-column: 1 / 3;
+`;
+
+const PriceMax = styled(InfoStyle)`
+  grid-column: 3 / 5;
+`;
+
+export default CoinInfo;

--- a/front/src/components/CoinList.tsx
+++ b/front/src/components/CoinList.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import { ChildrenProps } from '../types/types';
 
 const List = styled.div`
-  width: 75vw;
+  width: 50vw;
 
   ${({ theme }) => {
     return css`

--- a/front/src/components/Title.tsx
+++ b/front/src/components/Title.tsx
@@ -48,8 +48,8 @@ const DarkModeButton = styled(Center)`
 `;
 
 const Header = styled.header`
-  width: 75vw;
-  height: 20vh;
+  width: 50vw;
+  height: 10vh;
 
   display: flex;
   align-items: center;
@@ -63,7 +63,7 @@ const Header = styled.header`
         flex: 1;
         font-weight: ${theme.fonts.weight.bold};
         display: flex;
-        font-size: ${theme.fonts.size.lg};
+        font-size: ${theme.fonts.size.base};
       }
     `;
   }}

--- a/front/src/pages/coinDetail.tsx
+++ b/front/src/pages/coinDetail.tsx
@@ -8,6 +8,7 @@ import { fetchCoinIdApi, fetchCoinPriceApi } from '../api/api';
 import { Container } from '../layout/layout';
 
 import Title from '../components/Title';
+import CoinInfo from '../components/CoinInfo';
 
 const CoinDetail = ({ theme, toggleTheme }: ThemeProps) => {
   const { coinId } = useParams();
@@ -31,14 +32,7 @@ const CoinDetail = ({ theme, toggleTheme }: ThemeProps) => {
   return (
     <Container>
       <Title theme={theme} toggleTheme={toggleTheme} name={coinId} />
-      {loading ? (
-        <div>Loading</div>
-      ) : (
-        <>
-          <div>{JSON.stringify(info)}</div>
-          <div>{JSON.stringify(price)}</div>
-        </>
-      )}
+      {loading ? <div>Loading</div> : <CoinInfo info={info} price={price} />}
     </Container>
   );
 };

--- a/front/src/styles/styled.d.ts
+++ b/front/src/styles/styled.d.ts
@@ -46,6 +46,7 @@ declare module 'styled-components' {
       dark: string;
       light: string;
       primary: string;
+      secondary: string;
       bgColor: string;
       textColor: string;
     };

--- a/front/src/styles/theme.ts
+++ b/front/src/styles/theme.ts
@@ -48,6 +48,7 @@ const colors = {
 const lightThemeColors = {
   ...colors,
   primary: '#22b8cf',
+  secondary: '#324B50',
   bgColor: colors.white,
   textColor: colors.dark,
 };
@@ -55,6 +56,7 @@ const lightThemeColors = {
 const darkThemeColors = {
   ...colors,
   primary: '#22b8cf',
+  secondary: '#324B50',
   bgColor: colors.dark,
   textColor: colors.white,
 };

--- a/front/src/types/types.tsx
+++ b/front/src/types/types.tsx
@@ -81,3 +81,8 @@ export interface PriceType {
     };
   };
 }
+
+export interface CoinInfoProps {
+  info: InfoType | undefined;
+  price: PriceType | undefined;
+}


### PR DESCRIPTION
## 내용
- CoinDetail Page에 CoinInfo라는 컴포넌트 만들고 스타일링하였다. 

### 고쳐야할 점
- HOME 화면에 각 비트 항목들의 블록이 아니라 text를 눌러야 링크 이동한다는 점
- 각 비트 항목 사진 넣기

### 관련 이슈
#18